### PR TITLE
Fix to typescript compile outDir

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "samtsc",
-    "version": "1.0.47",
+    "version": "1.0.48",
     "author": "Nikody Keating",
     "license": "MIT",
     "publisher": "mytaptrack",

--- a/src/sam/compiled-directory.js
+++ b/src/sam/compiled-directory.js
@@ -152,7 +152,7 @@ class SAMCompiledDirectory {
 
             if(this.tsconfigDir) {
                 logger.info('building path ', this.path);
-                compileTypescript(this.tsconfigDir, this.buildRoot, { library: this.isLibrary }, this.samconfig);
+                compileTypescript(this.tsconfigDir, this.buildRoot, { library: this.isLibrary, outDir: this.outDir }, this.samconfig);
                 logger.success('build complete', this.path);
             }
             if(!filePath || filePath.indexOf('package.json') >= 0) {

--- a/src/tsc-tools.js
+++ b/src/tsc-tools.js
@@ -2,6 +2,7 @@ const { execSync } = require('child_process');
 const fs = require('./file-system');
 const { resolve, relative } = require('path');
 const moment = require('moment');
+const { logger } = require('./logger');
 const pathHashes = {};
 
 const hashRoot = '.build/hash';
@@ -73,6 +74,10 @@ function execOnlyShowErrors(command, options) {
 function compileTypescript(sourceFolder, buildRoot, options = {}, samconfig = {}) {
     if(options.library) {
         const localOutDir = resolve(sourceFolder, options.outDir || '.');
+        if(options.outDir) {
+            logger.info('Removing outDir');
+            fs.rmdirSync(localOutDir);
+        }
         const outDir = resolve(process.cwd(), `${buildRoot}/${sourceFolder}`, options.outDir || '.');
         
         console.log('samtsc: Compiling tsc', options.compileFlags, sourceFolder);


### PR DESCRIPTION
There's an issue on windows where the outDir is not being removed or overwritten.  This update fixes that issue by removing the outDir directory before compiling into it